### PR TITLE
chore: add bncode to headers in orders api calls

### DIFF
--- a/src/__tests__/applepay.test.js
+++ b/src/__tests__/applepay.test.js
@@ -10,6 +10,7 @@ import { Applepay } from "../applepay";
 import { getMerchantDomain } from "../util";
 
 jest.mock("@paypal/sdk-client/src", () => ({
+  getPartnerAttributionID: () => "bn_code",
   getClientID: () =>
     "AdVrVyh_UduEct9CWFHsaHRXKVxbnCDleEJdVOZdb52qSjrWkKDNd6E1CNvd5BvNrGSsXzgQ238dGgZ4",
   getMerchantID: () => ["2V9L63AM2BYKC"],

--- a/src/applepay.js
+++ b/src/applepay.js
@@ -7,6 +7,7 @@ import {
   getBuyerCountry,
   getPayPalDomain,
   getPayPalAPIDomain,
+  getPartnerAttributionID,
 } from "@paypal/sdk-client/src";
 import { FPTI_KEY } from "@paypal/sdk-constants/src";
 
@@ -37,12 +38,14 @@ async function createOrder(
   payload: OrderPayload
 ): Promise<CreateOrderResponse> {
   const basicAuth = btoa(`${getClientID()}`);
+  const partnerAttributionId = getPartnerAttributionID();
 
   try {
     const accessToken = await fetch(`${getPayPalAPIDomain()}/v1/oauth2/token`, {
       method: "POST",
       headers: {
         Authorization: `Basic ${basicAuth}`,
+        'PayPal-Partner-Attribution-Id': partnerAttributionId,
       },
       body: "grant_type=client_credentials",
     })
@@ -255,11 +258,14 @@ function confirmOrder({
   if (billingContact?.countryCode) {
     billingContact.countryCode = billingContact.countryCode.toUpperCase();
   }
+  
+  const partnerAttributionId = getPartnerAttributionID();
 
   return fetch(`${getPayPalDomain()}/graphql?ApproveApplePayPayment`, {
     method: "POST",
     headers: {
       ...DEFAULT_GQL_HEADERS,
+      'PayPal-Partner-Attribution-Id': partnerAttributionId  
     },
     body: JSON.stringify({
       query: `

--- a/src/applepay.js
+++ b/src/applepay.js
@@ -45,7 +45,7 @@ async function createOrder(
       method: "POST",
       headers: {
         Authorization: `Basic ${basicAuth}`,
-        "PayPal-Partner-Attribution-Id": partnerAttributionId,
+        "PayPal-Partner-Attribution-Id": partnerAttributionId || "",
       },
       body: "grant_type=client_credentials",
     })
@@ -265,7 +265,7 @@ function confirmOrder({
     method: "POST",
     headers: {
       ...DEFAULT_GQL_HEADERS,
-      "PayPal-Partner-Attribution-Id": partnerAttributionId,
+      "PayPal-Partner-Attribution-Id": partnerAttributionId || "",
     },
     body: JSON.stringify({
       query: `

--- a/src/applepay.js
+++ b/src/applepay.js
@@ -45,7 +45,7 @@ async function createOrder(
       method: "POST",
       headers: {
         Authorization: `Basic ${basicAuth}`,
-        'PayPal-Partner-Attribution-Id': partnerAttributionId,
+        "PayPal-Partner-Attribution-Id": partnerAttributionId,
       },
       body: "grant_type=client_credentials",
     })
@@ -258,14 +258,14 @@ function confirmOrder({
   if (billingContact?.countryCode) {
     billingContact.countryCode = billingContact.countryCode.toUpperCase();
   }
-  
+
   const partnerAttributionId = getPartnerAttributionID();
 
   return fetch(`${getPayPalDomain()}/graphql?ApproveApplePayPayment`, {
     method: "POST",
     headers: {
       ...DEFAULT_GQL_HEADERS,
-      'PayPal-Partner-Attribution-Id': partnerAttributionId  
+      "PayPal-Partner-Attribution-Id": partnerAttributionId,
     },
     body: JSON.stringify({
       query: `


### PR DESCRIPTION
https://paypal.atlassian.net/browse/DTALTPAY-1294

Add bncode (paypal-partner-attribution-id) header so orders API calls (CSPS/CBPS downstream) will receive bncode

With data-partner-attribution-id:
[https://sh-pp-observability.us-central1.gcp.dev.paypalinc.com:8000/en-US/app/monitoring-splunk-app/log-vie[…]Amsmaster5int-g_checkoutbuyerplatserv_0](https://sh-pp-observability.us-central1.gcp.dev.paypalinc.com:8000/en-US/app/monitoring-splunk-app/log-view-event-details-dashboard?txnId=76861944f7b7512b&timeRange.earliest=1677093292&timeRange.latest=1677093592.999&machineName=msmaster5int-g_checkoutbuyerplatserv_0&corrId=000e1a85bca06&threadId=17&env=msmaster&poolName=checkoutbuyerplatserv&host=gcp%3Amsmaster5int-g_checkoutbuyerplatserv_0)

Without data-partner-attribution-id:
[https://sh-pp-observability.us-central1.gcp.dev.paypalinc.com:8000/en-US/app/monitoring-splunk-app/log-vie[…]Amsmaster4int-g_checkoutbuyerplatserv_1](https://sh-pp-observability.us-central1.gcp.dev.paypalinc.com:8000/en-US/app/monitoring-splunk-app/log-view-event-details-dashboard?txnId=d756a4f07b7d69f2&timeRange.earliest=1677095056&timeRange.latest=1677095356.999&machineName=msmaster4int-g_checkoutbuyerplatserv_1&corrId=1d213b4b600e9&threadId=13&env=msmaster&poolName=checkoutbuyerplatserv&host=gcp%3Amsmaster4int-g_checkoutbuyerplatserv_1)

Dependent on corresponding xobuyer PR to pass this info to CBPS/CSPS