### PR TITLE
Remove client order create

### DIFF
--- a/src/__tests__/applepay.test.js
+++ b/src/__tests__/applepay.test.js
@@ -54,30 +54,6 @@ global.btoa = btoa;
 global.atob = atob;
 
 describe("applepay", () => {
-  describe("Order", () => {
-    it("Creates Order", async () => {
-      const applepay = Applepay();
-
-      const { id, status } = await applepay.createOrder({
-        intent: "CAPTURE",
-        purchase_units: [
-          {
-            amount: {
-              currency_code: "USD",
-              value: "1.00",
-            },
-            payee: {
-              merchant_id: "2V9L63AM2BYKC",
-            },
-          },
-        ],
-      });
-
-      expect(id).toBeTruthy();
-      expect(status).toBe("CREATED");
-    });
-  });
-
   describe("Config", () => {
     it("GetAppelPayConfig", async () => {
       const applepay = Applepay();

--- a/src/__tests__/util.test.js
+++ b/src/__tests__/util.test.js
@@ -1,11 +1,6 @@
 /* @flow */
 
-import {
-  getMerchantDomain,
-  getCurrency,
-  getCreateOrderPayLoad,
-  mapGetConfigResponse,
-} from "../util";
+import { getMerchantDomain, getCurrency, mapGetConfigResponse } from "../util";
 
 global.window = Object.create(window);
 
@@ -41,67 +36,6 @@ describe("util", () => {
   describe("getCurrency", () => {
     it("Should return USD by default", () => {
       expect(getCurrency()).toBe("USD");
-    });
-  });
-
-  describe("getCreateOrderPayLoad", () => {
-    it("should create order with capture Intent and default payee Information", () => {
-      const requestPayLoad = {
-        purchase_units: [
-          {
-            amount: {
-              currency_code: "USD",
-              value: "0.99",
-            },
-          },
-        ],
-      };
-      expect(getCreateOrderPayLoad(requestPayLoad)).toStrictEqual({
-        intent: "CAPTURE",
-        purchase_units: [
-          {
-            amount: {
-              currency_code: "USD",
-              value: "0.99",
-            },
-            payee: {
-              merchant_id: "2V9L63AM2BYKC",
-            },
-          },
-        ],
-        payer: undefined,
-        application_context: undefined,
-      });
-    });
-
-    it("should create order with passed in information", () => {
-      const requestPayLoad = {
-        intent: "AUTHORIZE",
-        purchase_units: [
-          {
-            amount: {
-              currency_code: "USD",
-              value: "0.99",
-            },
-          },
-        ],
-      };
-      expect(getCreateOrderPayLoad(requestPayLoad)).toStrictEqual({
-        intent: "AUTHORIZE",
-        purchase_units: [
-          {
-            amount: {
-              currency_code: "USD",
-              value: "0.99",
-            },
-            payee: {
-              merchant_id: "2V9L63AM2BYKC",
-            },
-          },
-        ],
-        payer: undefined,
-        application_context: undefined,
-      });
     });
   });
 

--- a/src/applepay.js
+++ b/src/applepay.js
@@ -6,7 +6,6 @@ import {
   getLogger,
   getBuyerCountry,
   getPayPalDomain,
-  getPayPalAPIDomain,
   getPartnerAttributionID,
 } from "@paypal/sdk-client/src";
 import { FPTI_KEY } from "@paypal/sdk-constants/src";
@@ -27,7 +26,6 @@ import type {
 import {
   FPTI_TRANSITION,
   FPTI_CUSTOM_KEY,
-  DEFAULT_API_HEADERS,
   DEFAULT_GQL_HEADERS,
 } from "./constants";
 import { logApplePayEvent } from "./logging";

--- a/src/applepay.js
+++ b/src/applepay.js
@@ -258,7 +258,7 @@ function confirmOrder({
   if (billingContact?.countryCode) {
     billingContact.countryCode = billingContact.countryCode.toUpperCase();
   }
-  
+
   const partnerAttributionId = getPartnerAttributionID();
 
   return fetch(`${getPayPalDomain()}/graphql?ApproveApplePayPayment`, {

--- a/src/applepay.js
+++ b/src/applepay.js
@@ -258,7 +258,7 @@ function confirmOrder({
   if (billingContact?.countryCode) {
     billingContact.countryCode = billingContact.countryCode.toUpperCase();
   }
-
+  
   const partnerAttributionId = getPartnerAttributionID();
 
   return fetch(`${getPayPalDomain()}/graphql?ApproveApplePayPayment`, {

--- a/src/types.js
+++ b/src/types.js
@@ -32,11 +32,6 @@ export type GQLConfigResponse = {|
   supportedNetworks: $ReadOnlyArray<string>,
 |};
 
-export type CreateOrderResponse = {|
-  id: string,
-  status: string,
-|};
-
 export type ApplePaySession = {|
   displayName: string,
   domainName: string,
@@ -128,7 +123,6 @@ export type ValidateMerchantResponse = {|
 |};
 
 export type ApplepayType = {|
-  createOrder(OrderPayload): Promise<CreateOrderResponse>,
   config(): Promise<ConfigResponse | PayPalApplePayErrorType>,
   validateMerchant(
     ValidateMerchantParams

--- a/src/util.js
+++ b/src/util.js
@@ -15,35 +15,6 @@ export function getCurrency(): string {
   return getSDKQueryParam("currency", "USD");
 }
 
-type CreateOrderPayLoad = {|
-  purchase_units: $ReadOnlyArray<{|
-    amount: {| currency_code: string, value: string |},
-  |}>,
-  intent: string,
-  payer: any,
-  application_context: any,
-|};
-
-export function getCreateOrderPayLoad(requestPayLoad: any): CreateOrderPayLoad {
-  const merchant_id = getMerchantID();
-  let { purchase_units, intent, payer, application_context } = requestPayLoad;
-  purchase_units = purchase_units.map((purchaseUnit) => {
-    return {
-      ...purchaseUnit,
-      payee: merchant_id && {
-        merchant_id,
-      },
-    };
-  });
-
-  return {
-    purchase_units,
-    intent: intent || ORDER_INTENT.CAPTURE,
-    payer,
-    application_context,
-  };
-}
-
 export function mapGetConfigResponse(
   applepayConfig: GQLConfigResponse
 ): ConfigResponse {

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,8 @@
 /* eslint-disable eslint-comments/disable-enable-pair */
-/* eslint-disable flowtype/no-weak-types */
-/* @flow */
-import { getSDKQueryParam, getMerchantID } from "@paypal/sdk-client/src";
 
-import { ORDER_INTENT } from "./constants";
+/* @flow */
+import { getSDKQueryParam } from "@paypal/sdk-client/src";
+
 import type { ConfigResponse, GQLConfigResponse } from "./types";
 
 export function getMerchantDomain(): string {


### PR DESCRIPTION
https://paypal.atlassian.net/browse/DTALTPAY-1308
Remove client-side order creation:
This method won't be used in applepay component. 
Merchants are instructed to use server-side order creation in applepay component from the `session.onpaymentauthorized` callback as per the [developer docs (in progress)](https://paypal-my.sharepoint.com/:w:/p/ythakur/Ebdrnb4LjZtJiOmZaYgmhyIB5SPPZT1D-tDRUHlwah7WGw?email=jscheinhorn%40paypal.com&e=4%3Aj1CU1u&at=9&wdLOR=c306921D7-01B7-CF4A-9E20-6E323F84417A)

Before (createOrder):
![image](https://user-images.githubusercontent.com/29203245/225380909-78453045-2fbe-4ae4-bcd5-a44542a7bcc8.png)


After (no createOrder):
![image](https://user-images.githubusercontent.com/29203245/225381009-50812d2b-c100-43be-9627-2be79f43ce5f.png)
