### PR TITLE
feat: apple pay MTN for recurring payments

### DIFF
--- a/src/__tests__/applepay.test.js
+++ b/src/__tests__/applepay.test.js
@@ -55,7 +55,7 @@ global.atob = atob;
 
 describe("applepay", () => {
   describe("Config", () => {
-    it("GetAppelPayConfig", async () => {
+    it.skip("GetAppelPayConfig", async () => {
       const applepay = Applepay();
       const config = await applepay.config();
       expect(config).toEqual({
@@ -69,6 +69,8 @@ describe("applepay", () => {
           "supportsCredit",
           "supportsDebit",
         ],
+        tokenNotificationURL:
+          "https://api.sandbox.paypal.com/v1/payment-provider/applepay",
       });
     });
   });

--- a/src/__tests__/applepay.test.js
+++ b/src/__tests__/applepay.test.js
@@ -55,7 +55,7 @@ global.atob = atob;
 
 describe("applepay", () => {
   describe("Config", () => {
-    it.skip("GetAppelPayConfig", async () => {
+    it("GetAppelPayConfig", async () => {
       const applepay = Applepay();
       const config = await applepay.config();
       expect(config).toEqual({
@@ -87,7 +87,9 @@ describe("applepay", () => {
       });
     } catch (err) {
       expect(err.name).toBe("PayPalApplePayError");
-      expect(err.message.includes("NOT_ENABLED_FOR_APPLE_PAY")).toBe(true);
+      expect(
+        err.message.includes("APPLE_PAY_MERCHANT_SESSION_VALIDATION_ERROR")
+      ).toBe(true);
       expect(err.paypalDebugId).toEqual(expect.any(String));
     }
   });

--- a/src/applepay.js
+++ b/src/applepay.js
@@ -51,7 +51,8 @@ function config(): Promise<ConfigResponse | PayPalApplePayErrorType> {
                       merchantCountry,
                       supportedNetworks,
                       isEligible,
-                      merchantCapabilities
+                      merchantCapabilities,
+                      tokenNotificationURL
                     }
                   }`,
       variables: {

--- a/src/types.js
+++ b/src/types.js
@@ -23,6 +23,7 @@ export type ConfigResponse = {|
   currencyCode: string,
   merchantCapabilities: $ReadOnlyArray<string>,
   supportedNetworks: $ReadOnlyArray<string>,
+  tokenNotificationURL: string,
 |};
 
 export type GQLConfigResponse = {|
@@ -30,6 +31,7 @@ export type GQLConfigResponse = {|
   merchantCountry: string,
   merchantCapabilities: $ReadOnlyArray<string>,
   supportedNetworks: $ReadOnlyArray<string>,
+  tokenNotificationURL: string,
 |};
 
 export type ApplePaySession = {|


### PR DESCRIPTION
### Description
This adds a new query field `tokenNotificationUrl` to applepayConfig graphql query to accommodate recurring Apple payments.


### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
https://paypal.atlassian.net/browse/DTALTPAY-1910
As part of apple pay recurring payment the tokenNotificationUrl needs to be sent in GetApplePayConfig API response so that it can be mapped in the ApplePayPaymentRequest
Ref - https://paypal.atlassian.net/browse/DTALTPAY-1875
For ex:

```
{
    "countryCode": "US",
    "currencyCode": "USD",
    "merchantCapabilities": [
        ...
    ],
    ...
    ,
    "recurringPaymentRequest": {
        ...
        "tokenNotificationURL": "https://api.paypal.com/v1/payment-provider/applepay"
    },
    ...
}

```
### Reproduction Steps (if applicable)
### Screenshots (if applicable)
<img width="1603" alt="image" src="https://github.com/paypal/paypal-applepay-components/assets/22331155/1aaaa833-86ec-4a60-9220-8421b1c74dc0">

### Dependent Changes (if applicable)
Dependent [xobuyer changes](https://github.paypal.com/PayPal-R/xobuyernodeserv/pull/3781) are already Live
